### PR TITLE
removing obsolete plugin from build.settings

### DIFF
--- a/Sample/build.settings
+++ b/Sample/build.settings
@@ -16,14 +16,9 @@ settings = {
   },
         
     plugins = {
-
         -- For production, Vungle SDK is obtained from Corona server
         ["plugin.vungle"] = {
             publisherId = "com.vungle"
-        },
-
-        ["plugin.google.play.services"] = {
-            publisherId = "com.coronalabs"
         },
     }, 
 }


### PR DESCRIPTION
This plugin was out for several years now and not compatible with modern build system.